### PR TITLE
Skip doc generation if no README.md

### DIFF
--- a/test/make.sh
+++ b/test/make.sh
@@ -116,15 +116,15 @@ function generate_docs() {
   echo "Generating markdown docs with terraform-docs"
   local path tmpfile
   while read -r path; do
-    # shellcheck disable=SC2119
-    tmpfile="$(maketemp)"
-    echo "terraform-docs markdown ${path}"
-    terraform-docs markdown "${path}" > "${tmpfile}"
-    if ! [[ -e "${path}/README.md" ]]; then
-      echo '[^]: (autogen_docs_start)' > "${path}/README.md"
-      echo '[^]: (autogen_docs_end)'  >> "${path}/README.md"
+    if [[ -e "${path}/README.md" ]]; then
+      # shellcheck disable=SC2119
+      tmpfile="$(maketemp)"
+      echo "terraform-docs markdown ${path}"
+      terraform-docs markdown "${path}" > "${tmpfile}"
+      helpers/combine_docfiles.py "${path}"/README.md "${tmpfile}"
+    else
+      echo "Skipping ${path} because README.md does not exist."
     fi
-    helpers/combine_docfiles.py "${path}"/README.md "${tmpfile}"
   done < <(find_files . -name '*.tf' -print0 \
     | compat_xargs -0 -n1 dirname \
     | sort -u)


### PR DESCRIPTION
Without this patch document generation is executed for any directory
containing `*.tf` files.  We decided to not generate documentation if
there is no README file [1], this patch implements the decision.

[1]: https://github.com/terraform-google-modules/terraform-google-startup-scripts/pull/5#discussion_r247254206