### PR TITLE
Assemble stdlib.content from snippets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BUILD_BATS_MOCK_VERSION ?= 2f9811faf43593ad7b59a0f245d8807b776e5072
 BUILD_BATS_SUPPORT_VERSION ?= 004e707638eedd62e0481e8cdc9223ad471f12ee
 DOCKER_IMAGE_BATS := cftk/bats
 # DOCKER_TAG_BATS is the image semver and has no correlation to bats versions
-DOCKER_TAG_BATS ?= 0.5.0
+DOCKER_TAG_BATS ?= 0.6.0
 
 # All is the first target in the file so it will get picked up when you just run 'make' on its own
 all: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace generate_docs
@@ -103,7 +103,7 @@ docker_bats_parallel:
 	docker run --rm -it \
 		-v $(CURDIR):/cftk/workdir \
 		${DOCKER_IMAGE_BATS}:${DOCKER_TAG_BATS} \
-		/bin/bash -c "time find test/spec/ -name '*.bats' -print0 | xargs -0 -P4 --no-run-if-empty -n1 bats"
+		/bin/bash -c "terraform init && time find test/spec/ -name '*.bats' -print0 | xargs -0 -P4 --no-run-if-empty -n1 bats"
 
 # Run docker bats shell
 .PHONY: docker_bats_shell

--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ ok 4 E_UNKNOWN_ARG error code is 10
 [^]: (autogen_docs_start)
 
 
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| enable_init_gsutil_crcmod_el | If not false, include stdlib::init_gsutil_crcmod_el() prior to executing startup-script-custom.  Call this function from startup-script-custom to initialize gsutil as per https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod#centos-rhel-and-fedora Intended for CentOS, RHEL and Fedora systems. | string | `false` | no |
+
 ## Outputs
 
 | Name | Description |

--- a/build/docker/bats/Dockerfile
+++ b/build/docker/bats/Dockerfile
@@ -19,6 +19,7 @@ FROM alpine:3.8
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
   bash \
+  unzip \
   curl \
   git
 
@@ -27,6 +28,11 @@ ENV APP_BASE_DIR="/cftk"
 RUN mkdir -p "${APP_BASE_DIR}/home" \
   "${APP_BASE_DIR}/bin" \
   "${APP_BASE_DIR}/workdir"
+
+# Terraform
+WORKDIR ${APP_BASE_DIR}
+RUN curl -o terraform.zip https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip
+RUN unzip terraform.zip -d "${APP_BASE_DIR}/bin"
 
 # bats
 WORKDIR ${APP_BASE_DIR}

--- a/files/init_gsutil_crcmod_el.sh
+++ b/files/init_gsutil_crcmod_el.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install the compiled version of crcmod to get faster checksums when
+# transferring objects from GCS.  This function is intended for Enterprise Linux
+# flavor operating systems.  See:
+# https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
+stdlib::init_gsutil_crcmod_el() {
+  if gsutil version -l | grep -qix 'compiled crcmod: True'; then
+    stdlib::debug "Skipping init_gsutil_crcmod_el() because gsutil version -l reports compiled crcmod: True"
+    return 0
+  fi
+  # Install dependencies
+  stdlib::info "gsutil -version -l reports compiled crcmod is not true"
+  stdlib::info "BEGIN: gsutil crcmod compilation and installation"
+  stdlib::cmd yum -y install gcc python-devel python-setuptools redhat-rpm-config
+  # Use the correct python version in a subshell to avoid pollution of the
+  # calling environment.
+  (
+    set +u # avoid MANPATH unbound variable issue.
+    eval "$(grep -m1 'source .*/enable' /usr/bin/gsutil)"
+    stdlib::cmd easy_install -U pip
+    stdlib::cmd pip uninstall crcmod
+    stdlib::cmd pip install -U crcmod
+  )
+  stdlib::info "END: gsutil crcmod compilation and installation"
+}

--- a/files/startup-script-stdlib-body.sh
+++ b/files/startup-script-stdlib-body.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+stdlib::main() {
+  DELETE_AT_EXIT="$(mktemp -d)"
+  readonly DELETE_AT_EXIT
+
+  # Initialize state required by other functions, e.g. debug()
+  stdlib::init
+  stdlib::debug "Loaded startup-script-stdlib as an executable."
+
+  stdlib::load_config_values
+
+  stdlib::run_startup_script_custom
+}
+
+# if script is being executed and not sourced.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  stdlib::finish() {
+    [[ -d "${DELETE_AT_EXIT:-}" ]] && rm -rf "${DELETE_AT_EXIT}"
+  }
+  trap stdlib::finish EXIT
+
+  stdlib::main "$@"
+fi

--- a/files/startup-script-stdlib-head.sh
+++ b/files/startup-script-stdlib-head.sh
@@ -246,25 +246,3 @@ stdlib::mktemp() {
   TMPDIR="${DELETE_AT_EXIT:-${TMPDIR}}" mktemp "$@"
 }
 
-stdlib::main() {
-  DELETE_AT_EXIT="$(mktemp -d)"
-  readonly DELETE_AT_EXIT
-
-  # Initialize state required by other functions, e.g. debug()
-  stdlib::init
-  stdlib::debug "Loaded startup-script-stdlib as an executable."
-
-  stdlib::load_config_values
-
-  stdlib::run_startup_script_custom
-}
-
-# if script is being executed and not sourced.
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  stdlib::finish() {
-    [[ -d "${DELETE_AT_EXIT:-}" ]] && rm -rf "${DELETE_AT_EXIT}"
-  }
-  trap stdlib::finish EXIT
-
-  stdlib::main "$@"
-fi

--- a/main.tf
+++ b/main.tf
@@ -14,3 +14,14 @@
  * limitations under the License.
  */
 
+locals {
+  stdlib_head = "${file("${path.module}/files/startup-script-stdlib-head.sh")}"
+  stdlib_body = "${file("${path.module}/files/startup-script-stdlib-body.sh")}"
+  # List representing complete content, to be concatenated together.
+  stdlib_list = [
+    "${local.stdlib_head}",
+    "${local.stdlib_body}",
+  ]
+  # Final content output to the user
+  stdlib = "${join("", local.stdlib_list)}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,5 +16,5 @@
 
 output "content" {
   description = "startup-script-stdlib.sh content as a string value."
-  value       = "${file("${path.module}/files/startup-script-stdlib.sh")}"
+  value       = "${local.stdlib}"
 }

--- a/test/spec/init_gsutil_crcmod_el.bats
+++ b/test/spec/init_gsutil_crcmod_el.bats
@@ -1,0 +1,21 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load "test_helper/load"
+
+@test "stdlib::init_gsutil_crcmod_el is not defined by default" {
+  run type -t stdlib::init_gsutil_crcmod_el
+  assert_failure
+  assert_output ''
+}

--- a/test/spec/init_gsutil_crcmod_el_enabled.bats
+++ b/test/spec/init_gsutil_crcmod_el_enabled.bats
@@ -1,0 +1,25 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load "test_helper/load"
+
+setup() {
+  TF_VAR_enable_init_gsutil_crcmod_el="true" source_stdlib
+}
+
+@test "stdlib::init_gsutil_crcmod_el is defined when input var enable_init_gsutil_crcmod_el=true" {
+  run type -t stdlib::init_gsutil_crcmod_el
+  assert_success
+  assert_output 'function'
+}

--- a/test/spec/test_helper/load.bash
+++ b/test/spec/test_helper/load.bash
@@ -117,8 +117,17 @@ fi
 
 # Use in setup(), separated out so setup() may be overridden.
 source_stdlib() {
+  local statefile
+  statefile="$(bats_mktemp)"
+  stdlib="$(bats_mktemp)"
+
+  ( cd "${BATS_TEST_DIRNAME%/}/../../" || return 1;
+    terraform init -input=false;
+    terraform apply -input=false -state-out="${statefile}";
+    terraform output -state="${statefile}" content > "${stdlib}")
   # shellcheck source=/dev/null
-  source "${BATS_TEST_DIRNAME%/}/../../files/startup-script-stdlib.sh"
+  source "${stdlib}"
+  rm -f "${stdlib}" "${statefile}"
 }
 
 # Load and initialize the function library before each test.

--- a/variables.tf
+++ b/variables.tf
@@ -13,17 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-locals {
-  stdlib_head = "${file("${path.module}/files/startup-script-stdlib-head.sh")}"
-  gsutil_el   = "${var.enable_init_gsutil_crcmod_el ? file("${path.module}/files/init_gsutil_crcmod_el.sh") : ""}"
-  stdlib_body = "${file("${path.module}/files/startup-script-stdlib-body.sh")}"
-  # List representing complete content, to be concatenated together.
-  stdlib_list = [
-    "${local.stdlib_head}",
-    "${local.gsutil_el}",
-    "${local.stdlib_body}",
-  ]
-  # Final content output to the user
-  stdlib = "${join("", local.stdlib_list)}"
+variable "enable_init_gsutil_crcmod_el" {
+  description = "If not false, include stdlib::init_gsutil_crcmod_el() prior to executing startup-script-custom.  Call this function from startup-script-custom to initialize gsutil as per https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod#centos-rhel-and-fedora Intended for CentOS, RHEL and Fedora systems."
+  default     = "false"
 }


### PR DESCRIPTION
Without this patch the stdlib script is a single flat file.  In [1] the
idea of splitting functionality out, to be opted-in using Terraform input
variables has been proposed.

The remaining functionality to be ported to stdlib is somewhat
platform-specific.  Managing sudoers, configuring init scripts, and setting
up gsutil with crcmod.  Pluggable functionality to opt-in to platform
specific behavior should be added ahead of these features so they are not
forced on everyone.

This patch envisions two approaches to opt-in behavior.  Neither approach
is implemented by this patch, only the groundwork to assemble the complete
stdlib content from fragments.

 1. Feature flags such as enable_init_gsutil_crcmod_el for functionality
    maintained directly in the startup-scripts module.
 2. A general purpose `user_content` to serve the use case of
    centralizing project specific functionality.  The intended use case
    is to provide a single place for multiple teams working together to
    add org-wide changes and functionality.  An example of this use case
    is one organization using a `set_dns()` function to manage DNS
    across many teams.  While this could be accomplished with the
    accounts module, the use case remains, to provide a single place to
    make broad changes in behavior.  NOTE: perhaps this use case is
    better served by the module taking in a URL to a GCS bucket and
    sourcing org-specific functionality from that location.

Note, templates have not been used because file fragments accomplish the
same goal, Terraform template behavior is changing soon in version 0.12,
and the `*.sh` files allow the automated shellcheck checks to run
unmodified.

[1]:
https://github.com/terraform-google-modules/terraform-google-startup-scripts/pull/11#issuecomment-456855295