### PR TITLE
Add CI scripts

### DIFF
--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Entry point for CI Integration Tests
+
+echo "Integration tests not yet implemented" >&2
+exit 1

--- a/test/ci_lint.sh
+++ b/test/ci_lint.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Entry point for CI Lint Checks.
+
+set -x
+exec make check_shell \
+  check_python \
+  check_golang \
+  check_terraform  \
+  check_docker \
+  check_base_files  \
+  test_check_headers  \
+  check_headers  \
+  check_trailing_whitespace

--- a/test/ci_spec.sh
+++ b/test/ci_spec.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Entry point for spec tests.  This script is run within the context of a
+# https://github.com/karlkfi/concourse-dcind Docker image.
+
+set -x
+set -e
+set -u
+apk add --update make
+make docker_build_bats
+exec make docker_bats


### PR DESCRIPTION
This patch adds CI script entry points called by CI pipeline jobs.  The
intent is to reduce friction when updating lint, spec and integration
tests by not requiring changes to the pipeline definitions themselves.
This intent follows separation of concerns where the CI pipeline
definition is separated as cleanly as possible from the actual test
execution.