### PR TITLE
Add stdlib::get_from_bucket functionality and tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -35,3 +35,8 @@ suites:
       name: "terraform"
       command_timeout: 1800
       root_module_directory: test/fixtures/simple_example
+  - name: "gsutil"
+    driver:
+      name: "terraform"
+      command_timeout: 1800
+      root_module_directory: test/fixtures/gsutil

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,6 +25,7 @@ platforms:
 
 verifier:
   name: terraform
+  color: false
   systems:
     - name: system
       backend: local

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ test_integration_docker: integration_test_image
 		--workdir /terraform-google-startup-scripts \
 		--env SERVICE_ACCOUNT_JSON \
 		--env PROJECT_ID \
+		--env REGION \
 		${DOCKER_IMAGE_INTEGRATION_URI} \
 		/bin/bash -c make test_integration
 
@@ -158,5 +159,6 @@ docker_run: integration_test_image
 		--workdir /terraform-google-startup-scripts \
 		--env SERVICE_ACCOUNT_JSON \
 		--env PROJECT_ID \
+		--env REGION \
 		${DOCKER_IMAGE_INTEGRATION_URI} \
-		/bin/bash
+		/bin/bash -c 'source test/ci_integration.sh && setup_environment && exec /bin/bash'

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ ok 4 E_UNKNOWN_ARG error code is 10
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| enable_get_from_bucket | If not false, include stdlib::get_from_bucket() prior to executing startup-script-custom.  Requires gsutil in the PATH.  See also enable_init_gsutil_crcmod_el feature flag. | string | `false` | no |
 | enable_init_gsutil_crcmod_el | If not false, include stdlib::init_gsutil_crcmod_el() prior to executing startup-script-custom.  Call this function from startup-script-custom to initialize gsutil as per https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod#centos-rhel-and-fedora Intended for CentOS, RHEL and Fedora systems. | string | `false` | no |
 
 ## Outputs

--- a/examples/gsutil/README.md
+++ b/examples/gsutil/README.md
@@ -1,0 +1,35 @@
+# Startup Script gsutil functionality
+
+While in this directory, run `terraform init` then `terraform plan` and
+`terraform apply` to boot an instance which executes a custom startup script
+within the context of the startup scripts library.
+
+See the [Simple Example](/examples/simple_example/README.md) for detailed
+general instructions.
+
+This example demonstrates the use of the feature flags to include the following
+functions:
+
+ 1. `stdlib::init_gsutil_crcmod_el`
+ 2. `stdlib::get_from_bucket`
+
+[^]: (autogen_docs_start)
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| project_id | The project_id to deploy the example instance into.  (e.g. "simple-sample-project-1234") | string | - | yes |
+| region | The region to deploy to | string | - | yes |
+| url | The url to fetch in the startup script.  This URL is passed via instance metadata to the startup script.  (e.g. ifconfig.co/city) | string | `http://ifconfig.co/json` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| nat_ip | Public IP address of the example compute instance. |
+| project_id |  |
+| region |  |
+
+[^]: (autogen_docs_end)

--- a/examples/gsutil/main.tf
+++ b/examples/gsutil/main.tf
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  version = "~> 1.20"
+  project = "${var.project_id}"
+  region  = "${var.region}"
+  zone    = "${var.region}-a"
+}
+
+module "startup-scripts" {
+  source                       = "../../"
+  enable_init_gsutil_crcmod_el = true
+  enable_get_from_bucket       = true
+}
+
+data "google_compute_image" "os" {
+  project = "centos-cloud"
+  family  = "centos-7"
+}
+
+resource "random_id" "resource_name_suffix" {
+  byte_length = 4
+}
+
+#    webhook_token = "${random_id.startup_scripts_github_webhook_token.hex}"
+
+# Storage bucket used by startup-script-custom and stdlib::get_from_bucket
+resource "google_storage_bucket" "example" {
+  name          = "startup-scripts-${random_id.resource_name_suffix.hex}"
+  location      = "${var.region}"
+  storage_class = "REGIONAL"
+}
+
+resource "google_storage_bucket_object" "message" {
+  name    = "message.txt"
+  content = "${var.message}"
+  bucket  = "${google_storage_bucket.example.name}"
+}
+
+data "template_file" "startup-script-custom" {
+  template = "${file("${path.module}/templates/startup-script-custom.tpl")}"
+  vars = {
+    bucket  = "${google_storage_bucket_object.message.bucket}"
+    object  = "${google_storage_bucket_object.message.name}"
+    content = "${google_storage_bucket_object.message.content}"
+  }
+}
+
+resource "google_compute_instance" "example" {
+  name           = "startup-scripts-gsutil1"
+  description    = "Startup Scripts Example"
+  machine_type   = "f1-micro"
+  can_ip_forward = false
+
+  metadata {
+    startup-script        = "${module.startup-scripts.content}"
+    startup-script-custom = "${data.template_file.startup-script-custom.rendered}"
+  }
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+  }
+
+  boot_disk {
+    auto_delete = true
+    initialize_params {
+      image = "${data.google_compute_image.os.self_link}"
+      type  = "pd-standard"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral IP
+    }
+  }
+}

--- a/examples/gsutil/main.tf
+++ b/examples/gsutil/main.tf
@@ -89,4 +89,9 @@ resource "google_compute_instance" "example" {
       // Ephemeral IP
     }
   }
+
+  service_account {
+    email  = "${var.service_account_email}"
+    scopes = ["storage-ro"]
+  }
 }

--- a/examples/gsutil/main.tf
+++ b/examples/gsutil/main.tf
@@ -36,8 +36,6 @@ resource "random_id" "resource_name_suffix" {
   byte_length = 4
 }
 
-#    webhook_token = "${random_id.startup_scripts_github_webhook_token.hex}"
-
 # Storage bucket used by startup-script-custom and stdlib::get_from_bucket
 resource "google_storage_bucket" "example" {
   name          = "startup-scripts-${random_id.resource_name_suffix.hex}"

--- a/examples/gsutil/outputs.tf
+++ b/examples/gsutil/outputs.tf
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value = "${var.project_id}"
+}
+
+output "region" {
+  value = "${var.region}"
+}
+
+output "nat_ip" {
+  description = "Public IP address of the example compute instance."
+  value       = "${google_compute_instance.example.network_interface.0.access_config.0.nat_ip}"
+}

--- a/examples/gsutil/outputs.tf
+++ b/examples/gsutil/outputs.tf
@@ -15,11 +15,13 @@
  */
 
 output "project_id" {
-  value = "${var.project_id}"
+  description = "The project id used when managing resources."
+  value       = "${var.project_id}"
 }
 
 output "region" {
-  value = "${var.region}"
+  description = "The region used when managing resources."
+  value       = "${var.region}"
 }
 
 output "nat_ip" {

--- a/examples/gsutil/templates/startup-script-custom.tpl
+++ b/examples/gsutil/templates/startup-script-custom.tpl
@@ -1,0 +1,16 @@
+#! /bin/bash
+#
+# This is an example of how stdlib::get_from_bucket behaves.
+#
+# Check for crcmod
+# https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
+stdlib::cmd gsutil version -l
+# Check the message in the object is the expected content
+tmpdir="$$(mktemp -d)"
+# This should create a file named `${object}` in the target directory
+stdlib::get_from_bucket -u "gs://${bucket}/${object}" -d "$${tmpdir}"
+echo 'EXPECTED: ${content}'
+echo -n 'ACTUAL: '
+cat "$${tmpdir}/${object}"
+
+echo "Finished with startup-script-custom example"

--- a/examples/gsutil/templates/startup-script-custom.tpl
+++ b/examples/gsutil/templates/startup-script-custom.tpl
@@ -2,12 +2,19 @@
 #
 # This is an example of how stdlib::get_from_bucket behaves.
 #
+
+# EXPECT compiled crcmod: False
+echo "679EBF864666 $(gsutil version -l | grep '^compiled crcmod:')"
+# Exercise the behavior of compiling in crcmod
+stdlib::init_gsutil_crcmod_el
+# Expect compiled crcmod: True
+echo "28BBEF21C095 $(gsutil version -l | grep '^compiled crcmod:')"
+
 # Check for crcmod
 # https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
 stdlib::info 'TEST UUID E62A3897-AAA0-4577-A564-F00B4B54869B'
-stdlib::cmd gsutil version -l
 # Check the message in the object is the expected content
-tmpdir="$$(mktemp -d)"
+tmpdir="$(mktemp -d)"
 # This should create a file named `${object}` in the target directory
 stdlib::get_from_bucket -u "gs://${bucket}/${object}" -d "$${tmpdir}"
 echo 'EXPECTED: ${content}'

--- a/examples/gsutil/templates/startup-script-custom.tpl
+++ b/examples/gsutil/templates/startup-script-custom.tpl
@@ -4,6 +4,7 @@
 #
 # Check for crcmod
 # https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod
+stdlib::info 'TEST UUID E62A3897-AAA0-4577-A564-F00B4B54869B'
 stdlib::cmd gsutil version -l
 # Check the message in the object is the expected content
 tmpdir="$$(mktemp -d)"
@@ -13,4 +14,4 @@ echo 'EXPECTED: ${content}'
 echo -n 'ACTUAL: '
 cat "$${tmpdir}/${object}"
 
-echo "Finished with startup-script-custom example"
+echo "Finished with startup-script-custom example 3FF02EC9-BFFE-4B47-BEE7-C98A07818251"

--- a/examples/gsutil/variables.tf
+++ b/examples/gsutil/variables.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project_id to deploy the example instance into.  (e.g. \"simple-sample-project-1234\")"
+}
+
+variable "region" {
+  description = "The region to deploy to"
+}
+
+variable "url" {
+  description = "The url to fetch in the startup script.  This URL is passed via instance metadata to the startup script.  (e.g. ifconfig.co/city)"
+  default     = "http://ifconfig.co/json"
+}
+
+variable "message" {
+  description = "The content to place in a bucket object message.txt. startup-script-custom fetches this object and validate this message against the content as an end-to-end example of stdlib::get_from_bucket()."
+  default     = "Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b"
+}

--- a/examples/gsutil/variables.tf
+++ b/examples/gsutil/variables.tf
@@ -22,6 +22,10 @@ variable "region" {
   description = "The region to deploy to"
 }
 
+variable "service_account_email" {
+  description = "The service acocunt email to associate with the example instance.  Should have storage.buckets.get to use stdlib::get_from_bucket"
+}
+
 variable "message" {
   description = "The content to place in a bucket object message.txt. startup-script-custom fetches this object and validate this message against the content as an end-to-end example of stdlib::get_from_bucket()."
   default     = "Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b"

--- a/examples/gsutil/variables.tf
+++ b/examples/gsutil/variables.tf
@@ -22,11 +22,6 @@ variable "region" {
   description = "The region to deploy to"
 }
 
-variable "url" {
-  description = "The url to fetch in the startup script.  This URL is passed via instance metadata to the startup script.  (e.g. ifconfig.co/city)"
-  default     = "http://ifconfig.co/json"
-}
-
 variable "message" {
   description = "The content to place in a bucket object message.txt. startup-script-custom fetches this object and validate this message against the content as an end-to-end example of stdlib::get_from_bucket()."
   default     = "Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b"

--- a/files/get_from_bucket.sh
+++ b/files/get_from_bucket.sh
@@ -1,0 +1,60 @@
+#! /bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Given a url and filename, download an object to the vardir. This function uses
+# gsutil to fetch from the bucket.  Note, the service account for the instance
+# must be properly configured with a role having authorization to get objects
+# from the bucket.  See Product/mktmail/commit/39fa9b8 for an example of the
+# necessary IAM role.
+#
+# This function is intended for single file downloads and no attempt is made to
+# verify the checksum other than the default behavior of gsutil.
+#
+# This function should have no other platform dependencies other than gsutil.
+stdlib::get_from_bucket() {
+  local OPTIND opt url fname dir="${VARDIR:-/var/lib/startup}"
+  while getopts ":u:f:d:" opt; do
+    case "${opt}" in
+    u) url="${OPTARG}" ;;
+    f) fname="${OPTARG}" ;;
+    d) dir="${OPTARG}" ;;
+    :)
+      stdlib::mandatory_argument -n stdlib::get_from_bucket -f "$OPTARG"
+      return "${E_MISSING_MANDATORY_ARG}"
+      ;;
+    *)
+      stdlib::error 'Usage: stdlib::get_from_bucket -u <url> -f <file name> -h <Content hash> -d <directory>'
+      stdlib::info 'For example: stdlib::get_from_bucket -u gs://mybucket/foo.tgz -d /var/tmp'
+      return "${E_UNKNOWN_ARG}"
+      ;;
+    esac
+  done
+  # Trivially compute the filename from the URL if unspecified.
+  if [[ -z "${fname}" ]]; then
+    fname=${url##*/}
+    stdlib::debug "Computed filename='${fname}' given URL."
+  fi
+  [[ -d "${dir}" ]] || mkdir "${dir}"
+  local attempt=1
+  local max_attempts=10
+  while [[ $attempt -lt $max_attempts ]]; do
+    if stdlib::cmd gsutil -q cp "${url}" "${dir}/${fname}"; then
+      break
+    else
+      stdlib::error "gsutil reported non-zero exit code fetching ${url}.  Retrying (${attempt}/${max_attempts})"
+      ((attempt++))
+    fi
+  done
+}

--- a/files/get_from_bucket.sh
+++ b/files/get_from_bucket.sh
@@ -35,7 +35,7 @@ stdlib::get_from_bucket() {
       return "${E_MISSING_MANDATORY_ARG}"
       ;;
     *)
-      stdlib::error 'Usage: stdlib::get_from_bucket -u <url> -f <file name> -h <Content hash> -d <directory>'
+      stdlib::error 'Usage: stdlib::get_from_bucket -u <url> -f <file name> -d <directory>'
       stdlib::info 'For example: stdlib::get_from_bucket -u gs://mybucket/foo.tgz -d /var/tmp'
       return "${E_UNKNOWN_ARG}"
       ;;

--- a/files/get_from_bucket.sh
+++ b/files/get_from_bucket.sh
@@ -16,8 +16,7 @@
 # Given a url and filename, download an object to the vardir. This function uses
 # gsutil to fetch from the bucket.  Note, the service account for the instance
 # must be properly configured with a role having authorization to get objects
-# from the bucket.  See Product/mktmail/commit/39fa9b8 for an example of the
-# necessary IAM role.
+# from the bucket.
 #
 # This function is intended for single file downloads and no attempt is made to
 # verify the checksum other than the default behavior of gsutil.

--- a/files/startup-script-stdlib-head.sh
+++ b/files/startup-script-stdlib-head.sh
@@ -15,16 +15,6 @@
 
 # Standard library of functions useful for startup scripts.
 
-# Pending UX behaviors
-# TODO(jmccune): call mandatory_argument() before E_MISSING_MANDATORY_ARG
-# TODO(jmccune): add -c <name> for alternate startup-script-custom name
-# Pending initialization functions:
-# TODO(jmccune): gsutil initialization w/ crcmod
-# Pending operational functions:
-# TODO(jmccune): get_from_bucket()
-# TODO(jmccune): setup_init_script()
-# TODO(jmccune): setup_sudoers()
-
 # These are outside init_global_vars so logging functions work with the most
 # basic case of `source startup-script-stdlib.sh`
 readonly SYSLOG_DEBUG_PRIORITY="${SYSLOG_DEBUG_PRIORITY:-syslog.debug}"

--- a/files/startup-script-stdlib-head.sh
+++ b/files/startup-script-stdlib-head.sh
@@ -236,3 +236,23 @@ stdlib::mktemp() {
   TMPDIR="${DELETE_AT_EXIT:-${TMPDIR}}" mktemp "$@"
 }
 
+# Return a nice error message if a mandatory argument is missing.
+stdlib::mandatory_argument() {
+  local OPTIND opt name flag
+  while getopts ":n:f:" opt; do
+    case "$opt" in
+    n) name="${OPTARG}" ;;
+    f) flag="${OPTARG}" ;;
+    :)
+      stdlib::error "Invalid argument: -${OPTARG} requires an argument to stdlib::mandatory_argument()"
+      return "${E_MISSING_MANDATORY_ARG}"
+      ;;
+    *)
+      stdlib::error "Unknown argument: -${OPTARG}"
+      stdlib::info "Usage: stdlib::mandatory_argument -n <name> -f <flag>"
+      return "${E_UNKNOWN_ARG}"
+      ;;
+    esac
+  done
+  stdlib::error "Invalid argument: -${flag} requires an argument to ${name}()."
+}

--- a/main.tf
+++ b/main.tf
@@ -15,13 +15,15 @@
  */
 
 locals {
-  stdlib_head = "${file("${path.module}/files/startup-script-stdlib-head.sh")}"
-  gsutil_el   = "${var.enable_init_gsutil_crcmod_el ? file("${path.module}/files/init_gsutil_crcmod_el.sh") : ""}"
-  stdlib_body = "${file("${path.module}/files/startup-script-stdlib-body.sh")}"
+  stdlib_head     = "${file("${path.module}/files/startup-script-stdlib-head.sh")}"
+  gsutil_el       = "${var.enable_init_gsutil_crcmod_el ? file("${path.module}/files/init_gsutil_crcmod_el.sh") : ""}"
+  get_from_bucket = "${var.enable_get_from_bucket ? file("${path.module}/files/get_from_bucket.sh") : ""}"
+  stdlib_body     = "${file("${path.module}/files/startup-script-stdlib-body.sh")}"
   # List representing complete content, to be concatenated together.
   stdlib_list = [
     "${local.stdlib_head}",
     "${local.gsutil_el}",
+    "${local.get_from_bucket}",
     "${local.stdlib_body}",
   ]
   # Final content output to the user

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -34,6 +34,7 @@ finish() {
 # use with kitchen-terraform, inspec, and gcloud.
 setup_environment() {
   local tmpfile
+  local uuid
   tmpfile="$(mktemp)"
   echo "${SERVICE_ACCOUNT_JSON}" > "${tmpfile}"
 
@@ -46,6 +47,10 @@ setup_environment() {
   # Terraform input variables
   export TF_VAR_project_id="${PROJECT_ID}"
   export TF_VAR_region="${REGION:-us-east4}"
+
+  # Unique ID used for resource names
+  uuid="$(</proc/sys/kernel/random/uuid)"
+  export UNIQUE_ID="${uuid:0:8}"
 }
 
 main() {

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -34,7 +34,6 @@ finish() {
 # use with kitchen-terraform, inspec, and gcloud.
 setup_environment() {
   local tmpfile
-  local uuid
   tmpfile="$(mktemp)"
   echo "${SERVICE_ACCOUNT_JSON}" > "${tmpfile}"
 
@@ -47,10 +46,6 @@ setup_environment() {
   # Terraform input variables
   export TF_VAR_project_id="${PROJECT_ID}"
   export TF_VAR_region="${REGION:-us-east4}"
-
-  # Unique ID used for resource names
-  uuid="$(</proc/sys/kernel/random/uuid)"
-  export UNIQUE_ID="${uuid:0:8}"
 }
 
 main() {

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -33,9 +33,10 @@ finish() {
 # running the tests to Terraform input variables.  Also setup credentials for
 # use with kitchen-terraform, inspec, and gcloud.
 setup_environment() {
-  local tmpfile
+  local tmpfile client_email
   tmpfile="$(mktemp)"
   echo "${SERVICE_ACCOUNT_JSON}" > "${tmpfile}"
+  client_email="$(jq -r .client_email "${tmpfile}")"
 
   # Terraform and most other tools respect GOOGLE_CREDENTIALS
   export GOOGLE_CREDENTIALS="${SERVICE_ACCOUNT_JSON}"
@@ -46,6 +47,7 @@ setup_environment() {
   # Terraform input variables
   export TF_VAR_project_id="${PROJECT_ID}"
   export TF_VAR_region="${REGION:-us-east4}"
+  export TF_VAR_service_account_email="${client_email}"
 }
 
 main() {

--- a/test/fixtures/gsutil/main.tf
+++ b/test/fixtures/gsutil/main.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "example" {
+  source           = "../../../examples/gsutil"
+  project_id       = "${var.project_id}"
+  region           = "${var.region}"
+}

--- a/test/fixtures/gsutil/main.tf
+++ b/test/fixtures/gsutil/main.tf
@@ -15,7 +15,8 @@
  */
 
 module "example" {
-  source           = "../../../examples/gsutil"
-  project_id       = "${var.project_id}"
-  region           = "${var.region}"
+  source                = "../../../examples/gsutil"
+  project_id            = "${var.project_id}"
+  region                = "${var.region}"
+  service_account_email = "${var.service_account_email}"
 }

--- a/test/fixtures/gsutil/outputs.tf
+++ b/test/fixtures/gsutil/outputs.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+# These outputs are fed to inspec as inputs.
+output "project_id" {
+  value = "${var.project_id}"
+}
+
+output "region" {
+  value = "${var.region}"
+}

--- a/test/fixtures/gsutil/variables.tf
+++ b/test/fixtures/gsutil/variables.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project_id to deploy the example instance into.  (e.g. \"simple-sample-project-1234\")"
+}
+
+variable "region" {
+  description = "The region to deploy to"
+}

--- a/test/fixtures/gsutil/variables.tf
+++ b/test/fixtures/gsutil/variables.tf
@@ -21,3 +21,7 @@ variable "project_id" {
 variable "region" {
   description = "The region to deploy to"
 }
+
+variable "service_account_email" {
+  description = "The service acocunt email to associate with the example instance.  Should have storage.buckets.get to use stdlib::get_from_bucket"
+}

--- a/test/fixtures/simulated_ci_environment/main.tf
+++ b/test/fixtures/simulated_ci_environment/main.tf
@@ -20,9 +20,11 @@ provider "google" {
 }
 
 locals {
+  # roles/storage.admin used by stdlib::get_from_bucket tests.
   required_service_account_project_roles = [
     "roles/compute.instanceAdmin",
     "roles/iam.serviceAccountUser",
+    "roles/storage.admin",
   ]
   required_project_services = [
     "cloudresourcemanager.googleapis.com",
@@ -33,8 +35,8 @@ locals {
 }
 
 resource "google_project" "startup_scripts" {
-  name            = "startup-scripts"
-  project_id      = "startup-scripts"
+  name            = "${var.project_id}"
+  project_id      = "${var.project_id}"
   folder_id       = "${var.folder_id}"
   billing_account = "${var.billing_account}"
 }

--- a/test/integration/gsutil/controls/gcloud.rb
+++ b/test/integration/gsutil/controls/gcloud.rb
@@ -16,8 +16,8 @@ project_id = attribute('project_id')
 region = attribute('region')
 zone = "#{region}-a"
 
-control 'simple startup-script-custom' do
-  title "With the simple example of startup-script-custom calling stdlib::info and stdlib::cmd"
+control 'enable_init_gsutil_crcmod_el' do
+  title "With enable_init_gsutil_crcmod_el=true"
 
   describe command("gcloud compute instances list --project #{project_id}") do
     its('exit_status') { should be 0 }

--- a/test/integration/gsutil/controls/gcloud.rb
+++ b/test/integration/gsutil/controls/gcloud.rb
@@ -51,19 +51,22 @@ control 'get_from_bucket with crcmod compilation' do
       its('stdout') { should match('28BBEF21C095 compiled crcmod: True') }
     end
 
-    context "when the instance does not have storage.objects.get access to the bucket" do
-      describe "stdlib::get_from_bucket should retry up to 10 times" do
-        9.times do |n|
-          its('stdout') { should match(%r{reported non-zero exit code fetching gs://startup-scripts-\w+/message\.txt.*?Retrying \(#{n+1}/10\)}) }
-        end
-      end
-    end
-
-    # context "stdlib::get_from_bucket -u gs://<bucket>/message.txt -d /path/to/tmpdir" do
-    #   describe "the content of message.txt fetched using stdlib::get_from_bucket" do
-    #     its('stdout') { should match('EXPECTED: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
-    #     its('stdout') { should match('ACTUAL: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
+    ##
+    # TODO: Move this to another example with no service account bound to the
+    # instance.
+    # context "when the instance does not have storage.objects.get access to the bucket" do
+    #   describe "stdlib::get_from_bucket should retry up to 10 times" do
+    #     9.times do |n|
+    #       its('stdout') { should match(%r{reported non-zero exit code fetching gs://startup-scripts-\w+/message\.txt.*?Retrying \(#{n+1}/10\)}) }
+    #     end
     #   end
     # end
+
+    context "stdlib::get_from_bucket -u gs://<bucket>/message.txt -d /path/to/tmpdir" do
+      describe "the content of message.txt fetched using stdlib::get_from_bucket" do
+        its('stdout') { should match('EXPECTED: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
+        its('stdout') { should match('ACTUAL: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
+      end
+    end
   end
 end

--- a/test/integration/gsutil/controls/gcloud.rb
+++ b/test/integration/gsutil/controls/gcloud.rb
@@ -42,19 +42,19 @@ control 'get_from_bucket with crcmod compilation' do
       its('stdout') { should match('28BBEF21C095 compiled crcmod: True') }
     end
 
-    context "when the instance does not have storage.objects.get access to the bucket" do
-      describe "stdlib::get_from_bucket should retry up to 10 times" do
-        9.times do |n|
-          its('stdout') { should match(%r{reported non-zero exit code fetching gs://startup-scripts-\w+/message\.txt.*?Retrying \(#{n+1}/10\)}) }
-        end
-      end
-    end
-
-    # context "stdlib::get_from_bucket -u gs://<bucket>/message.txt -d /path/to/tmpdir" do
-    #   describe "the content of message.txt fetched using stdlib::get_from_bucket" do
-    #     its('stdout') { should match('EXPECTED: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
-    #     its('stdout') { should match('ACTUAL: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
+    # context "when the instance does not have storage.objects.get access to the bucket" do
+    #   describe "stdlib::get_from_bucket should retry up to 10 times" do
+    #     9.times do |n|
+    #       its('stdout') { should match(%r{reported non-zero exit code fetching gs://startup-scripts-\w+/message\.txt.*?Retrying \(#{n+1}/10\)}) }
+    #     end
     #   end
     # end
+
+    context "stdlib::get_from_bucket -u gs://<bucket>/message.txt -d /path/to/tmpdir" do
+      describe "the content of message.txt fetched using stdlib::get_from_bucket" do
+        its('stdout') { should match('EXPECTED: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
+        its('stdout') { should match('ACTUAL: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
+      end
+    end
   end
 end

--- a/test/integration/gsutil/controls/gcloud.rb
+++ b/test/integration/gsutil/controls/gcloud.rb
@@ -19,16 +19,11 @@ zone = "#{region}-a"
 control 'enable_init_gsutil_crcmod_el' do
   title "With enable_init_gsutil_crcmod_el=true"
 
-  describe command("gcloud compute instances list --project #{project_id}") do
+  describe command("gcloud compute instances get-serial-port-output startup-scripts-gsutil1 --project #{project_id} --zone #{zone}") do
     its('exit_status') { should be 0 }
-    its('stderr') { should eq '' }
-    its('stdout') { should match(/startup-scripts-example.*RUNNING/) }
-  end
-
-  describe command("gcloud compute instances get-serial-port-output startup-scripts-example1 --project #{project_id} --zone #{zone}") do
-    its('exit_status') { should be 0 }
-    its('stderr') { should match(%r{Specify --start=\d+ in the next get-serial-port-output invocation to get only the new output starting from here})}
-    its('stdout') { should match(%r{Info \[\d+\]: Fetching http://ifconfig\.co/json}) }
+    its('stdout') { should match('TEST UUID E62A3897-AAA0-4577-A564-F00B4B54869B') }
+    its('stdout') { should match('compiled crcmod: True') }
+    its('stdout') { should match('Finished with startup-script-custom example 3FF02EC9-BFFE-4B47-BEE7-C98A07818251') }
     its('stdout') { should match('INFO startup-script: Return code 0.') }
   end
 end

--- a/test/integration/gsutil/controls/gcloud.rb
+++ b/test/integration/gsutil/controls/gcloud.rb
@@ -12,16 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project_id = attribute('project_id')
-region = attribute('region')
-zone = "#{region}-a"
+require 'retriable'
 
 control 'get_from_bucket with crcmod compilation' do
   title "With enable_init_gsutil_crcmod_el=true and enable_get_from_bucket=true"
 
   describe 'console output of startup-scripts-gsutil1' do
-    let :subject do
-      command("gcloud compute instances get-serial-port-output startup-scripts-gsutil1 --project #{project_id} --zone #{zone}")
+    # Avoid racing against the instance boot sequence
+    before :all do
+      Retriable.retriable(tries: 20) do
+        get_serial_port_output = "gcloud compute instances get-serial-port-output startup-scripts-gsutil1"
+        @cmd = command("#{get_serial_port_output} --project #{attribute('project_id')} --zone #{attribute('region')}-a")
+        if not %r{systemd: Startup finished}.match(@cmd.stdout)
+          raise StandardError, "Not found: 'systemd: Startup finished' in console output, cannot proceed"
+        end
+      end
+    end
+
+    subject do
+      @cmd
     end
 
     describe "Overall result of startup-script-custom" do
@@ -35,26 +44,26 @@ control 'get_from_bucket with crcmod compilation' do
     end
 
     describe "gsutil version -l before calling stdlib::init_gsutil_crcmod_el" do
-      its('stdout') { should match('679EBF864666 compiled crcmod: False') }
+      its('stdout', focus: true) { should match('679EBF864666 compiled crcmod: False') }
     end
 
     describe "gsutil version -l after calling stdlib::init_gsutil_crcmod_el" do
       its('stdout') { should match('28BBEF21C095 compiled crcmod: True') }
     end
 
-    # context "when the instance does not have storage.objects.get access to the bucket" do
-    #   describe "stdlib::get_from_bucket should retry up to 10 times" do
-    #     9.times do |n|
-    #       its('stdout') { should match(%r{reported non-zero exit code fetching gs://startup-scripts-\w+/message\.txt.*?Retrying \(#{n+1}/10\)}) }
-    #     end
-    #   end
-    # end
-
-    context "stdlib::get_from_bucket -u gs://<bucket>/message.txt -d /path/to/tmpdir" do
-      describe "the content of message.txt fetched using stdlib::get_from_bucket" do
-        its('stdout') { should match('EXPECTED: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
-        its('stdout') { should match('ACTUAL: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
+    context "when the instance does not have storage.objects.get access to the bucket" do
+      describe "stdlib::get_from_bucket should retry up to 10 times" do
+        9.times do |n|
+          its('stdout') { should match(%r{reported non-zero exit code fetching gs://startup-scripts-\w+/message\.txt.*?Retrying \(#{n+1}/10\)}) }
+        end
       end
     end
+
+    # context "stdlib::get_from_bucket -u gs://<bucket>/message.txt -d /path/to/tmpdir" do
+    #   describe "the content of message.txt fetched using stdlib::get_from_bucket" do
+    #     its('stdout') { should match('EXPECTED: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
+    #     its('stdout') { should match('ACTUAL: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
+    #   end
+    # end
   end
 end

--- a/test/integration/gsutil/inspec.yml
+++ b/test/integration/gsutil/inspec.yml
@@ -1,0 +1,8 @@
+name: gsutil
+attributes:
+  - name: project_id
+    required: true
+    type: string
+  - name: region
+    required: true
+    type: string

--- a/test/integration/simple_example/controls/gcloud.rb
+++ b/test/integration/simple_example/controls/gcloud.rb
@@ -19,12 +19,6 @@ zone = "#{region}-a"
 control 'simple startup-script-custom' do
   title "With the simple example of startup-script-custom calling stdlib::info and stdlib::cmd"
 
-  describe command("gcloud compute instances list --project #{project_id}") do
-    its('exit_status') { should be 0 }
-    its('stderr') { should eq '' }
-    its('stdout') { should match(/startup-scripts-example.*RUNNING/) }
-  end
-
   describe command("gcloud compute instances get-serial-port-output startup-scripts-example1 --project #{project_id} --zone #{zone}") do
     its('exit_status') { should be 0 }
     its('stderr') { should match(%r{Specify --start=\d+ in the next get-serial-port-output invocation to get only the new output starting from here})}

--- a/test/integration/simple_example/controls/gcloud.rb
+++ b/test/integration/simple_example/controls/gcloud.rb
@@ -12,16 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project_id = attribute('project_id')
-region = attribute('region')
-zone = "#{region}-a"
+require 'retriable'
 
 control 'simple startup-script-custom' do
   title "With the simple example of startup-script-custom calling stdlib::info and stdlib::cmd"
 
-  describe command("gcloud compute instances get-serial-port-output startup-scripts-example1 --project #{project_id} --zone #{zone}") do
+  describe "gcloud ... get-serial-port-output startup-scripts-example1" do
+    # Avoid racing against the instance boot sequence
+    before :all do
+      Retriable.retriable(tries: 20) do
+        get_serial_port_output = "gcloud compute instances get-serial-port-output startup-scripts-example1"
+        @cmd = command("#{get_serial_port_output} --project #{attribute('project_id')} --zone #{attribute('region')}-a")
+        if not %r{systemd: Startup finished}.match(@cmd.stdout)
+          raise StandardError, "Not found: 'systemd: Startup finished' in console output, cannot proceed"
+        end
+      end
+    end
+
+    subject do
+      @cmd
+    end
+
     its('exit_status') { should be 0 }
-    its('stderr') { should match(%r{Specify --start=\d+ in the next get-serial-port-output invocation to get only the new output starting from here})}
     its('stdout') { should match(%r{Info \[\d+\]: Fetching http://ifconfig\.co/json}) }
     its('stdout') { should match('INFO startup-script: Return code 0.') }
   end

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,8 @@ variable "enable_init_gsutil_crcmod_el" {
   description = "If not false, include stdlib::init_gsutil_crcmod_el() prior to executing startup-script-custom.  Call this function from startup-script-custom to initialize gsutil as per https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod#centos-rhel-and-fedora Intended for CentOS, RHEL and Fedora systems."
   default     = "false"
 }
+
+variable "enable_get_from_bucket" {
+  description = "If not false, include stdlib::get_from_bucket() prior to executing startup-script-custom.  Requires gsutil in the PATH.  See also enable_init_gsutil_crcmod_el feature flag."
+  default     = "false"
+}


### PR DESCRIPTION
Test coverage for the following functions which are optionally included via
feature flags.

 * stdlib::init_gsutil_crcmod_el
 * stdlib::get_from_bucket

# Do not merge until

 * [x] gsutil related integration tests have been added
 * [x] #12 merged
 * [x] #14 merged
