### PR TITLE
Use bundle exec kitchen in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,19 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ruby '2.5.3'
+
+source 'https://rubygems.org/' do
+  gem 'kitchen-terraform', '~> 4.1.0'
+end

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -24,7 +24,7 @@
 DELETE_AT_EXIT="$(mktemp -d)"
 finish() {
   echo 'BEGIN: finish() trap handler' >&2
-  kitchen destroy
+  bundle exec kitchen destroy
   [[ -d "${DELETE_AT_EXIT}" ]] && rm -rf "${DELETE_AT_EXIT}"
   echo 'END: finish() trap handler' >&2
 }
@@ -57,9 +57,9 @@ main() {
   setup_environment
   set -x
   # Execute the test lifecycle
-  kitchen create
-  kitchen converge
-  kitchen verify
+  bundle exec kitchen create
+  bundle exec kitchen converge
+  bundle exec kitchen verify
 }
 
 # if script is being executed and not sourced.


### PR DESCRIPTION
As per previous review from Aaron.  `bundle exec` is necessary to ensure
dependencies are loaded properly.