### PR TITLE
(WIP) Add stdlib::setup_sudoers

### DIFF
--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -149,8 +149,8 @@ $ curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata
 | Name | Description |
 |------|-------------|
 | nat_ip | Public IP address of the example compute instance. |
-| project_id |  |
-| region |  |
+| project_id | The project id used when managing resources. |
+| region | The region used when managing resources. |
 
 [^]: (autogen_docs_end)
 

--- a/files/setup_sudoers.sh
+++ b/files/setup_sudoers.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+# Read the metadata key named "sudoers" and add each comma separated value to
+# the sudoers file.
+stdlib::setup_sudoers() {
+  local user user_list sudoers_file
+  user_list="$(metadata_get -k 'project/attributes/sudoers')"
+
+  if [[ -z "${user_list}" ]]; then
+    stdlib::debug "Skipping sudoers setup.  The value of the project metadata key named sudoers is empty.  Set sudoers to a comma separated list to enable sudo support, e.g. sudoers=jmccune,pames"
+    return 0
+  fi
+
+  sudoers_file="$(mktemp)"
+  cp /etc/sudoers "${sudoers_file}"
+
+  for user in ${user_list//,/ }; do
+    if grep -q "^${user}"'\b' "${sudoers_file}"; then
+      stdlib::debug "User ${user} is already in /etc/sudoers, taking no action"
+    else
+      stdlib::info "Adding ${user} to /etc/sudoers"
+      echo -e "${user}\tALL= (ALL)\tNOPASSWD: ALL" >>"${sudoers_file}"
+    fi
+  done
+
+  if cmp --silent /etc/sudoers "${sudoers_file}"; then
+    stdlib::debug "No changes necessary to sudoers file, doing nothing."
+    return 0
+  else
+    stdlib::info "Staged changes to sudoers:"
+    diff -U2 /etc/sudoers "${sudoers_file}" || true
+    if visudo -cf "${sudoers_file}"; then
+      stdlib::info "Installing new /etc/sudoers file"
+      stdlib::cmd install -o 0 -g 0 -m 0440 "${sudoers_file}" /etc/sudoers
+      return $?
+    else
+      stdlib::error "Skipping modification of /etc/sudoers because the temporary sudoers file is invalid."
+      return 1
+    fi
+  fi
+}

--- a/test/fixtures/simulated_ci_environment/README.md
+++ b/test/fixtures/simulated_ci_environment/README.md
@@ -48,6 +48,6 @@ For example:
 
 | Name | Description |
 |------|-------------|
-| phoogle_sa | The SA KEY JSON content.  Store in GOOGLE_CREDENTIALS. |
+| service_account_private_key | The SA KEY JSON content.  Store in GOOGLE_CREDENTIALS.  This is equivalent to the `phoogle_sa` output in the infra repository |
 
 [^]: (autogen_docs_end)


### PR DESCRIPTION
Read the metadata key `sudoers` and configure each CSV listed username in
/etc/sudoers with full root access.