### PR TITLE
add stdlib::setup_init_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ ok 4 E_UNKNOWN_ARG error code is 10
 |------|-------------|:----:|:-----:|:-----:|
 | enable_get_from_bucket | If not false, include stdlib::get_from_bucket() prior to executing startup-script-custom.  Requires gsutil in the PATH.  See also enable_init_gsutil_crcmod_el feature flag. | string | `false` | no |
 | enable_init_gsutil_crcmod_el | If not false, include stdlib::init_gsutil_crcmod_el() prior to executing startup-script-custom.  Call this function from startup-script-custom to initialize gsutil as per https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod#centos-rhel-and-fedora Intended for CentOS, RHEL and Fedora systems. | string | `false` | no |
-| enable_setup_init_script | If true, include stdlib::setup_init_script() prior to executing startup-script-custom.  Call this function to load an init script from GCS into /etc/init.d and initialize it with chkconfig. This function depends on stdlib::get_from_bucket, so this input will be set to "false" if enable_get_from_bucket is "false" | string | `false` | no |
+| enable_setup_init_script | If true, include stdlib::setup_init_script() prior to executing startup-script-custom.  Call this function to load an init script from GCS into /etc/init.d and initialize it with chkconfig. This function depends on stdlib::get_from_bucket, so this input will be set to false if enable_get_from_bucket is false | string | `false` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ ok 4 E_UNKNOWN_ARG error code is 10
 |------|-------------|:----:|:-----:|:-----:|
 | enable_get_from_bucket | If not false, include stdlib::get_from_bucket() prior to executing startup-script-custom.  Requires gsutil in the PATH.  See also enable_init_gsutil_crcmod_el feature flag. | string | `false` | no |
 | enable_init_gsutil_crcmod_el | If not false, include stdlib::init_gsutil_crcmod_el() prior to executing startup-script-custom.  Call this function from startup-script-custom to initialize gsutil as per https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod#centos-rhel-and-fedora Intended for CentOS, RHEL and Fedora systems. | string | `false` | no |
-| setup_init_script | If not false, include stdlib::setup_init_script() prior to executing startup-script-custom.  ADD FUNCTION DESCRIPTION HERE | string | `false` | no |
+| enable_setup_init_script | If true, include stdlib::setup_init_script() prior to executing startup-script-custom.  Call this function to load an init script from GCS into /etc/init.d and initialize it with chkconfig. This function depends on stdlib::get_from_bucket, so this input will be set to "false" if enable_get_from_bucket is "false" | string | `false` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ ok 4 E_UNKNOWN_ARG error code is 10
 |------|-------------|:----:|:-----:|:-----:|
 | enable_get_from_bucket | If not false, include stdlib::get_from_bucket() prior to executing startup-script-custom.  Requires gsutil in the PATH.  See also enable_init_gsutil_crcmod_el feature flag. | string | `false` | no |
 | enable_init_gsutil_crcmod_el | If not false, include stdlib::init_gsutil_crcmod_el() prior to executing startup-script-custom.  Call this function from startup-script-custom to initialize gsutil as per https://cloud.google.com/storage/docs/gsutil/addlhelp/CRC32CandInstallingcrcmod#centos-rhel-and-fedora Intended for CentOS, RHEL and Fedora systems. | string | `false` | no |
+| setup_init_script | If not false, include stdlib::setup_init_script() prior to executing startup-script-custom.  ADD FUNCTION DESCRIPTION HERE | string | `false` | no |
 
 ## Outputs
 

--- a/examples/gsutil/README.md
+++ b/examples/gsutil/README.md
@@ -12,6 +12,7 @@ functions:
 
  1. `stdlib::init_gsutil_crcmod_el`
  2. `stdlib::get_from_bucket`
+ 3. `stdlib::setup_init_script`
 
 [^]: (autogen_docs_start)
 

--- a/examples/gsutil/init_scripts/init_script_sample
+++ b/examples/gsutil/init_scripts/init_script_sample
@@ -1,4 +1,3 @@
-# vi /path/to/init_script_sample.sh
 #!/bin/bash
 #
 # chkconfig: 345 10 90

--- a/examples/gsutil/init_scripts/init_script_sample
+++ b/examples/gsutil/init_scripts/init_script_sample
@@ -20,7 +20,7 @@ stop)
         stop
         ;;
 *)
-        echo $"Usage: $0 {start|stop}"
+        echo "Usage: $0 {start|stop}"
         RETVAL=2
 esac
 

--- a/examples/gsutil/init_scripts/init_script_sample
+++ b/examples/gsutil/init_scripts/init_script_sample
@@ -1,0 +1,28 @@
+# vi /path/to/init_script_sample.sh
+#!/bin/bash
+#
+# chkconfig: 345 10 90
+# description: Sample script that support chkconfig
+
+start() {
+         touch /var/tmp/init_script_sample
+         date > /var/tmp/init_script_sample
+}
+
+stop() {
+        rm -f /var/tmp/init_script_sample
+}
+
+case "$1" in
+start)
+        start
+        ;;
+stop)
+        stop
+        ;;
+*)
+        echo $"Usage: $0 {start|stop}"
+        RETVAL=2
+esac
+
+exit $RETVAL

--- a/examples/gsutil/main.tf
+++ b/examples/gsutil/main.tf
@@ -60,9 +60,9 @@ data "template_file" "startup-script-custom" {
   template = "${file("${path.module}/templates/startup-script-custom.tpl")}"
 
   vars = {
-    bucket  = "${google_storage_bucket_object.message.bucket}"
-    object  = "${google_storage_bucket_object.message.name}"
-    content = "${google_storage_bucket_object.message.content}"
+    bucket             = "${google_storage_bucket_object.message.bucket}"
+    object             = "${google_storage_bucket_object.message.name}"
+    content            = "${google_storage_bucket_object.message.content}"
     init_script_object = "${google_storage_bucket_object.init_script_sample.name}"
   }
 }
@@ -86,6 +86,7 @@ resource "google_compute_instance" "example" {
 
   boot_disk {
     auto_delete = true
+
     initialize_params {
       image = "${data.google_compute_image.os.self_link}"
       type  = "pd-standard"
@@ -94,6 +95,7 @@ resource "google_compute_instance" "example" {
 
   network_interface {
     network = "default"
+
     access_config {
       // Ephemeral IP
     }

--- a/examples/gsutil/main.tf
+++ b/examples/gsutil/main.tf
@@ -25,6 +25,7 @@ module "startup-scripts" {
   source                       = "../../"
   enable_init_gsutil_crcmod_el = true
   enable_get_from_bucket       = true
+  enable_setup_init_script     = true
 }
 
 data "google_compute_image" "os" {
@@ -49,12 +50,20 @@ resource "google_storage_bucket_object" "message" {
   bucket  = "${google_storage_bucket.example.name}"
 }
 
+resource "google_storage_bucket_object" "init_script_sample" {
+  name    = "init_script_sample"
+  content = "${file("${path.module}/init_scripts/init_script_sample")}"
+  bucket  = "${google_storage_bucket.example.name}"
+}
+
 data "template_file" "startup-script-custom" {
   template = "${file("${path.module}/templates/startup-script-custom.tpl")}"
+
   vars = {
     bucket  = "${google_storage_bucket_object.message.bucket}"
     object  = "${google_storage_bucket_object.message.name}"
     content = "${google_storage_bucket_object.message.content}"
+    init_script_object = "${google_storage_bucket_object.init_script_sample.name}"
   }
 }
 

--- a/examples/gsutil/templates/startup-script-custom.tpl
+++ b/examples/gsutil/templates/startup-script-custom.tpl
@@ -22,3 +22,10 @@ echo -n 'ACTUAL: '
 cat "$${tmpdir}/${object}"
 
 echo "Finished with startup-script-custom example 3FF02EC9-BFFE-4B47-BEE7-C98A07818251"
+
+
+echo "Downloading init scripts from GCS"
+stdlib::setup_init_script -u "gs://${bucket}/${init_script_object}" -f "${init_script_object}"
+echo 'Init script named ${init_script_object} loaded from GCS bucket installed in /etc/init.d and enabled with chkconfig command'
+echo 'EXPECTED: Service enabled status is 1'
+echo -n "ACTUAL: Service enabled status is " ; chkconfig --list ${init_script_object} 2>/dev/null | grep ${init_script_object} -w -c

--- a/examples/gsutil/templates/startup-script-custom.tpl
+++ b/examples/gsutil/templates/startup-script-custom.tpl
@@ -28,9 +28,9 @@ echo "Downloading init scripts from GCS"
 stdlib::setup_init_script -u "gs://${bucket}/${init_script_object}" -f "${init_script_object}"
 echo 'Init script named ${init_script_object} loaded from GCS bucket installed in /etc/init.d and enabled with chkconfig command'
 
-# Check if the service was properly installed using chkconfig 
+# Check if the service was properly installed using chkconfig
 echo 'EXPECTED: Service enabled status is 1'
-# Listing all enabled services and isolating the new service output. 
-# If there is a service with the exact same name as $init_script_object, 
+# Listing all enabled services and isolating the new service output.
+# If there is a service with the exact same name as $init_script_object,
 # the command "grep $init_script_object -w -c" will return 1
 echo -n "ACTUAL: Service enabled status is " ; chkconfig --list ${init_script_object} 2>/dev/null | grep ${init_script_object} -w -c

--- a/examples/gsutil/templates/startup-script-custom.tpl
+++ b/examples/gsutil/templates/startup-script-custom.tpl
@@ -27,5 +27,10 @@ echo "Finished with startup-script-custom example 3FF02EC9-BFFE-4B47-BEE7-C98A07
 echo "Downloading init scripts from GCS"
 stdlib::setup_init_script -u "gs://${bucket}/${init_script_object}" -f "${init_script_object}"
 echo 'Init script named ${init_script_object} loaded from GCS bucket installed in /etc/init.d and enabled with chkconfig command'
+
+# Check if the service was properly installed using chkconfig 
 echo 'EXPECTED: Service enabled status is 1'
+# Listing all enabled services and isolating the new service output. 
+# If there is a service with the exact same name as $init_script_object, 
+# the command "grep $init_script_object -w -c" will return 1
 echo -n "ACTUAL: Service enabled status is " ; chkconfig --list ${init_script_object} 2>/dev/null | grep ${init_script_object} -w -c

--- a/files/setup_init_script.sh
+++ b/files/setup_init_script.sh
@@ -17,11 +17,11 @@
 # stdlib::get_from_bucket which itself uses gsutil to fetch from the bucket.  
 #
 # This function is intended for single file downloads
+# To be properly installed, your init script should support chkconfig. 
+# See example init script in <path-to-module>/examples/gsutil/init_scripts/init_script for reference
 
-
-# Setup an init script from a GCS Bucket. The URL to the file in the GCS bucket
-# is passed as -u, and the file name as -f
-# The URL should the full URL pointing to the file 
+# Setup an init script from a GCS Bucket. The URL pointing to the init script file in the GCS bucket
+# is passed as -u, and the file name as -f.
 stdlib::setup_init_script() {
   local OPTIND opt url fname init_script_dir
   while getopts ":u:f:" opt; do
@@ -39,14 +39,8 @@ stdlib::setup_init_script() {
     esac
   done
 
-  # Trivially compute the filename from the URL if unspecified.
-  if [[ -z "${fname}" ]]; then
-    fname=${url##*/}
-    stdlib::debug "Computed init_script filename='${fname}' given URL."
-  fi
-
   init_script_dir="$(mktemp -d)"
-  stdlib::get_from_bucket -u "${url}" -d "${init_script_dir}"
+  stdlib::get_from_bucket -u "${url}" -f ${fname} -d "${init_script_dir}"
   stdlib::info 'Called stdlib::get_from_bucket' 
   stdlib::cmd install -o 0 -g 0 -m 0755 "${init_script_dir}/${fname}" "/etc/init.d/${fname}"
   stdlib::info 'Installed init script' 

--- a/files/setup_init_script.sh
+++ b/files/setup_init_script.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Given a url and filename, download an init script /etc/init.d and setup the init script. This function uses
+# stdlib::get_from_bucket which itself uses gsutil to fetch from the bucket.  
+#
+# This function is intended for single file downloads
+
+
+# Setup an init script from a GCS Bucket. The URL to the file in the GCS bucket
+# is passed as -u, and the file name as -f
+stdlib::setup_init_script() {
+  local OPTIND opt url fname init_script_dir
+  while getopts ":u:f:" opt; do
+    case "${opt}" in
+    u) url="${OPTARG}" ;;
+    f) fname="${OPTARG}" ;;
+    :)
+      stdlib::mandatory_argument -n stdlib::setup_init_script -f "$OPTARG"
+      return "${E_MISSING_MANDATORY_ARG}"
+      ;;
+    *)
+      stdlib::error 'Usage: stdlib::setup_init_script -u <url> -f <file name>'
+      return "${E_UNKNOWN_ARG}"
+      ;;
+    esac
+  done
+
+  # Trivially compute the filename from the URL if unspecified.
+  if [[ -z "${fname}" ]]; then
+    fname=${url##*/}
+    stdlib::debug "Computed init_script filename='${fname}' given URL."
+  fi
+
+  init_script_dir="$(mktemp -d)"
+  stdlib::get_from_bucket -u "${url}" -d "${init_script_dir}"
+  stdlib::info 'Called stdlib::get_from_bucket' 
+  stdlib::cmd install -o 0 -g 0 -m 0755 "${init_script_dir}/${fname}" "/etc/init.d/${fname}"
+  stdlib::info 'Installed init script' 
+  stdlib::cmd chkconfig --level 2345 "${fname}" on
+  stdlib::info 'Setup run levels for init script'
+}

--- a/files/setup_init_script.sh
+++ b/files/setup_init_script.sh
@@ -21,6 +21,7 @@
 
 # Setup an init script from a GCS Bucket. The URL to the file in the GCS bucket
 # is passed as -u, and the file name as -f
+# The URL should the full URL pointing to the file 
 stdlib::setup_init_script() {
   local OPTIND opt url fname init_script_dir
   while getopts ":u:f:" opt; do

--- a/files/setup_init_script.sh
+++ b/files/setup_init_script.sh
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 # Given a url and filename, download an init script into /etc/init.d and setup the init script. This function uses
-# stdlib::get_from_bucket which itself uses gsutil to fetch from the bucket.  
+# stdlib::get_from_bucket which itself uses gsutil to fetch from the bucket.
 #
 # This function is intended for single file downloads
-# To be properly installed, your init script should support chkconfig. 
+# To be properly installed, your init script should support chkconfig.
 # See example init script in <path-to-module>/examples/gsutil/init_scripts/init_script for reference
 
 # Setup an init script from a GCS Bucket. The URL pointing to the init script file in the GCS bucket
@@ -41,9 +41,9 @@ stdlib::setup_init_script() {
 
   init_script_dir="$(mktemp -d)"
   stdlib::get_from_bucket -u "${url}" -f "${fname}" -d "${init_script_dir}"
-  stdlib::info 'Called stdlib::get_from_bucket' 
+  stdlib::info 'Called stdlib::get_from_bucket'
   stdlib::cmd install -o 0 -g 0 -m 0755 "${init_script_dir}/${fname}" "/etc/init.d/${fname}"
-  stdlib::info 'Installed init script' 
+  stdlib::info 'Installed init script'
   stdlib::cmd chkconfig --level 2345 "${fname}" on
   stdlib::info 'Setup run levels for init script'
 }

--- a/files/setup_init_script.sh
+++ b/files/setup_init_script.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Given a url and filename, download an init script /etc/init.d and setup the init script. This function uses
+# Given a url and filename, download an init script into /etc/init.d and setup the init script. This function uses
 # stdlib::get_from_bucket which itself uses gsutil to fetch from the bucket.  
 #
 # This function is intended for single file downloads

--- a/files/setup_init_script.sh
+++ b/files/setup_init_script.sh
@@ -41,7 +41,6 @@ stdlib::setup_init_script() {
 
   init_script_dir="$(mktemp -d)"
   stdlib::get_from_bucket -u "${url}" -f "${fname}" -d "${init_script_dir}"
-  stdlib::info 'Called stdlib::get_from_bucket'
   stdlib::cmd install -o 0 -g 0 -m 0755 "${init_script_dir}/${fname}" "/etc/init.d/${fname}"
   stdlib::info 'Installed init script'
   stdlib::cmd chkconfig --level 2345 "${fname}" on

--- a/files/setup_init_script.sh
+++ b/files/setup_init_script.sh
@@ -40,7 +40,7 @@ stdlib::setup_init_script() {
   done
 
   init_script_dir="$(mktemp -d)"
-  stdlib::get_from_bucket -u "${url}" -f ${fname} -d "${init_script_dir}"
+  stdlib::get_from_bucket -u "${url}" -f "${fname}" -d "${init_script_dir}"
   stdlib::info 'Called stdlib::get_from_bucket' 
   stdlib::cmd install -o 0 -g 0 -m 0755 "${init_script_dir}/${fname}" "/etc/init.d/${fname}"
   stdlib::info 'Installed init script' 

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,6 @@ locals {
   stdlib_head     = "${file("${path.module}/files/startup-script-stdlib-head.sh")}"
   gsutil_el       = "${var.enable_init_gsutil_crcmod_el ? file("${path.module}/files/init_gsutil_crcmod_el.sh") : ""}"
   get_from_bucket = "${var.enable_get_from_bucket ? file("${path.module}/files/get_from_bucket.sh") : ""}"
-  #setup_init_script = "${var.enable_setup_init_script ? file("${path.module}/files/setup_init_script.sh") : ""}"
   setup_init_script = "${(var.enable_setup_init_script && var.enable_get_from_bucket) ? file("${path.module}/files/setup_init_script.sh") : ""}"
   stdlib_body     = "${file("${path.module}/files/startup-script-stdlib-body.sh")}"
   # List representing complete content, to be concatenated together.

--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,15 @@ locals {
   stdlib_head     = "${file("${path.module}/files/startup-script-stdlib-head.sh")}"
   gsutil_el       = "${var.enable_init_gsutil_crcmod_el ? file("${path.module}/files/init_gsutil_crcmod_el.sh") : ""}"
   get_from_bucket = "${var.enable_get_from_bucket ? file("${path.module}/files/get_from_bucket.sh") : ""}"
+  #setup_init_script = "${var.enable_setup_init_script ? file("${path.module}/files/setup_init_script.sh") : ""}"
+  setup_init_script = "${(var.enable_setup_init_script && var.enable_get_from_bucket) ? file("${path.module}/files/setup_init_script.sh") : ""}"
   stdlib_body     = "${file("${path.module}/files/startup-script-stdlib-body.sh")}"
   # List representing complete content, to be concatenated together.
   stdlib_list = [
     "${local.stdlib_head}",
     "${local.gsutil_el}",
     "${local.get_from_bucket}",
+    "${local.setup_init_script}",
     "${local.stdlib_body}",
   ]
   # Final content output to the user

--- a/test/integration/gsutil/controls/gcloud.rb
+++ b/test/integration/gsutil/controls/gcloud.rb
@@ -68,5 +68,13 @@ control 'get_from_bucket with crcmod compilation' do
         its('stdout') { should match('ACTUAL: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
       end
     end
+    
+    context "stdlib::setup_init_script -n <init_script_name> -k <metadata_key>" do
+      describe "the confirmation or error message of a new init script fetched fm a metadata key using stdlib::setup_init_script" do
+         its('stdout') { should match('ACTUAL: Service enabled status is 1') }
+         its('stdout') { should match('EXPECTED: Service enabled status is 1') }
+      end
+    end
+    
   end
 end

--- a/test/integration/gsutil/controls/gcloud.rb
+++ b/test/integration/gsutil/controls/gcloud.rb
@@ -69,12 +69,12 @@ control 'get_from_bucket with crcmod compilation' do
       end
     end
     
-    context "stdlib::setup_init_script -n <init_script_name> -k <metadata_key>" do
+    context "stdlib::setup_init_script -u gs://<bucket>/<file_name> -f <file_name>" do
       describe "the confirmation or error message of a new init script fetched fm a metadata key using stdlib::setup_init_script" do
          its('stdout') { should match('ACTUAL: Service enabled status is 1') }
          its('stdout') { should match('EXPECTED: Service enabled status is 1') }
       end
     end
-    
+
   end
 end

--- a/test/integration/gsutil/controls/gcloud.rb
+++ b/test/integration/gsutil/controls/gcloud.rb
@@ -68,7 +68,7 @@ control 'get_from_bucket with crcmod compilation' do
         its('stdout') { should match('ACTUAL: Hello World! uuid=0afce28a-057b-42cf-a90f-493de3c0666b') }
       end
     end
-    
+
     context "stdlib::setup_init_script -u gs://<bucket>/<file_name> -f <file_name>" do
       describe "the confirmation or error message of a new init script fetched fm a metadata key using stdlib::setup_init_script" do
          its('stdout') { should match('ACTUAL: Service enabled status is 1') }

--- a/test/integration/gsutil/controls/gcloud.rb
+++ b/test/integration/gsutil/controls/gcloud.rb
@@ -70,7 +70,7 @@ control 'get_from_bucket with crcmod compilation' do
     end
 
     context "stdlib::setup_init_script -u gs://<bucket>/<file_name> -f <file_name>" do
-      describe "the confirmation or error message of a new init script fetched fm a metadata key using stdlib::setup_init_script" do
+      describe "checking that the init script is enabled" do
          its('stdout') { should match('ACTUAL: Service enabled status is 1') }
          its('stdout') { should match('EXPECTED: Service enabled status is 1') }
       end

--- a/variables.tf
+++ b/variables.tf
@@ -19,11 +19,11 @@ variable "enable_init_gsutil_crcmod_el" {
 }
 
 variable "enable_get_from_bucket" {
-  description = "If not false, include stdlib::setup_init_script() prior to executing startup-script-custom.  Requires gsutil in the PATH.  See also enable_init_gsutil_crcmod_el feature flag."
+  description = "If not false, include stdlib::get_from_bucket() prior to executing startup-script-custom.  Requires gsutil in the PATH.  See also enable_init_gsutil_crcmod_el feature flag."
   default     = "false"
 }
 
 variable "enable_setup_init_script" {
-  description = "If not false, include stdlib::setup_init_script() prior to executing startup-script-custom.   Call this function to load an init script from GCS into /etc/init.d and initialize it with chkconfig. This function depends on stdlib::get_from_bucket, so this input will be set to false if enable_get_from_bucket is false "
+  description = "If not false, include stdlib::setup_init_script() prior to executing startup-script-custom.   Call this function to load an init script from GCS into /etc/init.d and initialize it with chkconfig. This function depends on stdlib::get_from_bucket, so this function won't be enabled if enable_get_from_bucket is false."
   default     = "false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,11 @@ variable "enable_init_gsutil_crcmod_el" {
 }
 
 variable "enable_get_from_bucket" {
-  description = "If not false, include stdlib::get_from_bucket() prior to executing startup-script-custom.  Requires gsutil in the PATH.  See also enable_init_gsutil_crcmod_el feature flag."
+  description = "If not false, include stdlib::setup_init_script() prior to executing startup-script-custom.  Requires gsutil in the PATH.  See also enable_init_gsutil_crcmod_el feature flag."
+  default     = "false"
+}
+
+variable "enable_setup_init_script" {
+  description = "If not false, include stdlib::setup_init_script() prior to executing startup-script-custom.  ADD FUNCTION DESCRIPTION HERE"
   default     = "false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,6 @@ variable "enable_get_from_bucket" {
 }
 
 variable "enable_setup_init_script" {
-  description = "If not false, include stdlib::setup_init_script() prior to executing startup-script-custom.  ADD FUNCTION DESCRIPTION HERE"
+  description = "If not false, include stdlib::setup_init_script() prior to executing startup-script-custom.   Call this function to load an init script from GCS into /etc/init.d and initialize it with chkconfig. This function depends on stdlib::get_from_bucket, so this input will be set to false if enable_get_from_bucket is false "
   default     = "false"
 }


### PR DESCRIPTION
Drop #20 in favor of this.

setup_init_script downloads an init script from GCS into /etc/init.d an initializes it with chkconfig.